### PR TITLE
Add user-select: all prop to mention style

### DIFF
--- a/src/quill.mention.css
+++ b/src/quill.mention.css
@@ -35,6 +35,7 @@
   background-color: #d3e1eb;
   padding: 3px 0;
   margin-right: 2px;
+  user-select: all;
 }
 
 .mention > span {


### PR DESCRIPTION
With keyboard it's only possible to select the whole mention badge, while with mouse you still can select parts of badge (e.g. just last name). Adding `user-select: all` property to the mention will make it selectable as a single unit with mouse too,