### PR TITLE
Signal sent when mention is clicked

### DIFF
--- a/src/blots/mention.js
+++ b/src/blots/mention.js
@@ -5,6 +5,14 @@ const Embed = Quill.import("blots/embed");
 class MentionBlot extends Embed {
   static create(data) {
     const node = super.create();
+    /* When clicked, sends a signal to be catched by any client code */
+    node.addEventListener('click', function(ev) {
+        const event = document.createEvent("Event");
+        event.initEvent("mention-clicked", true, true);
+        event.value = data;
+        window.dispatchEvent(event);
+        ev.preventDefault();
+      }, false);
     const denotationChar = document.createElement("span");
     denotationChar.className = "ql-mention-denotation-char";
     denotationChar.innerHTML = data.denotationChar;


### PR DESCRIPTION
Allows any client code to receive a 'mention-clicked' signal when a mention is clicked. Useful to do some kind of navigation, show an info popup, etc