### PR TITLE
Signal when mention is clicked

### DIFF
--- a/src/blots/mention.js
+++ b/src/blots/mention.js
@@ -5,6 +5,15 @@ const Embed = Quill.import("blots/embed");
 class MentionBlot extends Embed {
   static create(data) {
     const node = super.create();
+    /* Sends a signal each time the node is clicked, so it can be listened to */
+    node.addEventListener('click', function(ev) {
+        const event = document.createEvent("Event");
+        event.initEvent("mention-clicked", true, true);
+        event.value = data;
+        event.clickEvent = ev;
+        window.dispatchEvent(event);
+        ev.preventDefault();
+      }, false); 
     const denotationChar = document.createElement("span");
     denotationChar.className = "ql-mention-denotation-char";
     denotationChar.innerHTML = data.denotationChar;


### PR DESCRIPTION
When a mention is clicked, a signal is sent, so it can be captured and applications can react to it