### PR TITLE
Versions Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,26 +13,26 @@
     "README.md"
   ],
   "dependencies": {
-    "quill": "^1.3.4"
+    "quill": "^1.3.7"
   },
   "devDependencies": {
-    "@ava/babel": "^0.4.0",
-    "@babel/core": "^7.10.2",
+    "@ava/babel": "^2.0.0",
+    "@babel/core": "^7.16.0",
     "@babel/plugin-transform-object-assign": "^7.10.1",
     "@babel/preset-env": "^7.10.2",
     "@babel/register": "^7.10.1",
+    "@rollup/plugin-babel": "^5.3.0",
     "ava": "^3.15.0",
-    "concurrently": "^5.2.0",
-    "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-prettier": "^3.1.4",
-    "prettier": "1.19.1",
-    "rollup": "^1.32.1",
-    "rollup-plugin-babel": "^4.4.0",
+    "concurrently": "^6.3.0",
+    "eslint": "^8.1.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "prettier": "2.4.1",
+    "rollup": "^2.58.3",
     "rollup-plugin-local-resolve": "^1.0.7",
     "rollup-plugin-postcss": "^4.0.0",
-    "rollup-plugin-terser": "^5.3.0",
-    "serve": "^11.3.2"
+    "rollup-plugin-terser": "^7.0.2",
+    "serve": "^12.0.1"
   },
   "scripts": {
     "start": "concurrently \"rollup -c -w\" \"serve docs\"",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import localResolve from "rollup-plugin-local-resolve";
-import babel from "rollup-plugin-babel";
+import babel from "@rollup/plugin-babel";
 import postcss from "rollup-plugin-postcss";
 import { terser } from "rollup-plugin-terser";
 import pkg from "./package.json";


### PR DESCRIPTION
npm was complaining about outdated dependencies for quill-mention in my project
I've run tests (those in package.json), no errors and I've run the project locally (including manual testing), seems to be fine. 